### PR TITLE
feat(extension) #6 added self-updating projection

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,9 @@ This library provides a stateless model repository for Axon Framework using sele
 The advantage is, that one does not need a `TrackingEventProcessor`, `TokenStore`  or other kind of persistence other than the Axon Server itself. 
 The `ModelRepository` directly accesses the event store and constructs the model on the fly by applying the events directly to the model.
 
+> **_NOTE:_**  This library is still under development. API changes may occur while using versions 0.x
+
+
 ## Usage
 
 To use the extension, simply include the artifact in your POM:
@@ -68,7 +71,7 @@ Then define a repository extending from `ModelRepository` class
 
 ```kotlin
 class CurrentBalanceModelRepository(eventStore: EventStore) :
-    ModelRepository<CurrentBalanceModel>(eventStore, CurrentBalanceModel::class.java, NoCache.INSTANCE)
+    ModelRepository<CurrentBalanceModel>(eventStore, CurrentBalanceModel::class.java)
 ```
 The repository can use a cache in the same manner aggregates can be cached. By default, the `NoCache` will be used.
 When using any cache implemented as in-memory solution, it is strongly advised to use an immutable model to be threadsafe.
@@ -84,6 +87,35 @@ If a cache was specified, the current instance is also put to the cache. When re
 compares the cached instances sequenceNumber with the lastSequenceNumber in the eventStore and applies missing events if any.
 
 For further examples refer to the *examples* module of this repository.
+
+### Self-updating cache projection
+
+As an extension to the ModelRepository, the `UpdatingModelRepository` is able to update the underlying cache as new events arrive for cached model entities.
+The UpdatingModelRepository must be registered via Axon configuration to be handled as an EventHandler. Easiest way is to create it as Spring bean (when using Spring)
+
+```kotlin
+@Component
+class CurrentBalanceModelRepository(eventStore: EventStore) :
+  UpdatingModelRepository<CurrentBalanceModel>(eventStore, CurrentBalanceModel::class.java) {
+  companion object : KLogging()
+  init {
+    /**
+     * Add a listener which fires on every model change. Can be used to trigger query subscriptions.
+     */
+    addModelUpdatedListener { logger.debug { "Updated ${it.bankAccountId}" } }
+  }
+}
+```
+
+## Configuration
+
+The `ModelRepository` and subclasses take a `ModelRepositoryConfig` object for more detailed configuration.
+
+| Parameter        | Description                                                                                                                                                                                                                                     | Default value  |
+|------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------|
+| cache            | the cache implementation to use                                                                                                                                                                                                                 | LRUCache(1024) |
+| cacheRefreshTime | Time in ms a cache entry is considered up-to-date and no eventStore will be queried for new/missed events.<br/>When using the UpdatingModelRepository` consider a value other than 0 to use the advantage of the self-updating repo.            | 0 (ms)         |
+| forceCacheInsert | Just for UpdatingModelRepository - Configures the behavior when an event of an uncached entity is received.<br/>When *false* the event is ignored, when *true*, a full replay of this entity is performed and the result is added to the cache. | false          |
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ The `ModelRepository` and subclasses take a `ModelRepositoryConfig` object for m
 |------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------|
 | cache            | the cache implementation to use                                                                                                                                                                                                                 | LRUCache(1024) |
 | cacheRefreshTime | Time in ms a cache entry is considered up-to-date and no eventStore will be queried for new/missed events.<br/>When using the UpdatingModelRepository` consider a value other than 0 to use the advantage of the self-updating repo.            | 0 (ms)         |
-| forceCacheInsert | Just for UpdatingModelRepository - Configures the behavior when an event of an uncached entity is received.<br/>When *false* the event is ignored, when *true*, a full replay of this entity is performed and the result is added to the cache. | false          |
+| forceCacheInsert | Just for UpdatingModelRepository - Configures the behavior when an event of an uncached entity is received.<br/>When _false_ the event is ignored, when _true_, a full replay of this entity is performed and the result is added to the cache. | false          |
 
 ## License
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,8 @@
+coverage:
+  status:
+    project:
+      default:
+        target: 80%    # the required coverage value
+    patch:
+      default:
+        target: 80%    # the required coverage value

--- a/examples/performance-test/http/testcalls.http
+++ b/examples/performance-test/http/testcalls.http
@@ -2,9 +2,9 @@ POST http://localhost:8080/data-generator/
 Content-Type: application/json
 
 {
-  "numAccounts": 100000,
-  "minInteractions": 200,
-  "maxInteractions": 400
+  "numAccounts": 100,
+  "minInteractions": 20,
+  "maxInteractions": 40
 }
 
 ###

--- a/examples/performance-test/src/main/kotlin/model/CurrentBalanceModel.kt
+++ b/examples/performance-test/src/main/kotlin/model/CurrentBalanceModel.kt
@@ -1,9 +1,8 @@
 package io.holixon.axon.projection.adhoc.model
 
-import io.holixon.axon.projection.adhoc.ModelRepository
+import io.holixon.axon.projection.adhoc.ModelRepositoryConfig
 import io.holixon.axon.projection.adhoc.UpdatingModelRepository
-import org.axonframework.common.caching.NoCache
-import org.axonframework.common.caching.WeakReferenceCache
+import mu.KLogging
 import org.axonframework.eventhandling.SequenceNumber
 import org.axonframework.eventhandling.Timestamp
 import org.axonframework.eventsourcing.eventstore.EventStore
@@ -44,4 +43,13 @@ data class CurrentBalanceModel(
 
 @Component
 class CurrentBalanceModelRepository(eventStore: EventStore) :
-  UpdatingModelRepository<CurrentBalanceModel>(eventStore, CurrentBalanceModel::class.java, WeakReferenceCache(), true)
+  UpdatingModelRepository<CurrentBalanceModel>(
+    eventStore,
+    CurrentBalanceModel::class.java,
+    ModelRepositoryConfig(forceCacheInsert = true)
+  ) {
+    companion object : KLogging()
+  init {
+    addModelUpdatedListener { logger.debug { "Updated ${it.bankAccountId}" } }
+  }
+}

--- a/examples/performance-test/src/main/kotlin/model/CurrentBalanceModel.kt
+++ b/examples/performance-test/src/main/kotlin/model/CurrentBalanceModel.kt
@@ -1,7 +1,9 @@
 package io.holixon.axon.projection.adhoc.model
 
 import io.holixon.axon.projection.adhoc.ModelRepository
+import io.holixon.axon.projection.adhoc.UpdatingModelRepository
 import org.axonframework.common.caching.NoCache
+import org.axonframework.common.caching.WeakReferenceCache
 import org.axonframework.eventhandling.SequenceNumber
 import org.axonframework.eventhandling.Timestamp
 import org.axonframework.eventsourcing.eventstore.EventStore
@@ -42,4 +44,4 @@ data class CurrentBalanceModel(
 
 @Component
 class CurrentBalanceModelRepository(eventStore: EventStore) :
-  ModelRepository<CurrentBalanceModel>(eventStore, CurrentBalanceModel::class.java, NoCache.INSTANCE)
+  UpdatingModelRepository<CurrentBalanceModel>(eventStore, CurrentBalanceModel::class.java, WeakReferenceCache(), true)

--- a/examples/performance-test/src/main/kotlin/model/events.kt
+++ b/examples/performance-test/src/main/kotlin/model/events.kt
@@ -16,3 +16,8 @@ data class MoneyDepositedEvent(
   val bankAccountId: UUID,
   val amountInEuroCent: Int
 )
+
+data class OwnerChangedEvent(
+  val bankAccountId: UUID,
+  val owner: String
+)

--- a/examples/performance-test/src/main/kotlin/rest/DataGenerationController.kt
+++ b/examples/performance-test/src/main/kotlin/rest/DataGenerationController.kt
@@ -3,6 +3,7 @@ package io.holixon.axon.projection.adhoc.rest
 import io.holixon.axon.projection.adhoc.model.BankAccountCreatedEvent
 import io.holixon.axon.projection.adhoc.model.MoneyDepositedEvent
 import io.holixon.axon.projection.adhoc.model.MoneyWithdrawnEvent
+import io.holixon.axon.projection.adhoc.model.OwnerChangedEvent
 import mu.KLogging
 import org.axonframework.eventhandling.DomainEventMessage
 import org.axonframework.eventhandling.GenericDomainEventMessage
@@ -73,12 +74,19 @@ class DataGenerationController(
             MoneyWithdrawnEvent::class.java.typeName,
             bankAccountId.toString(),
             i,
-            MoneyDepositedEvent(bankAccountId, Random.nextInt(100, 200))
+            MoneyWithdrawnEvent(bankAccountId, Random.nextInt(100, 200))
           )
         )
       }
-
     }
+
+    events.add(
+      GenericDomainEventMessage(
+        OwnerChangedEvent::class.java.typeName,
+        bankAccountId.toString(),
+        events.size.toLong(),
+        OwnerChangedEvent(bankAccountId, "Someone else"))
+      )
 
     eventStore.publish(events)
   }

--- a/extension/core/pom.xml
+++ b/extension/core/pom.xml
@@ -77,7 +77,12 @@
       <artifactId>junit-jupiter-engine</artifactId>
       <scope>test</scope>
     </dependency>
-
+    <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility-kotlin</artifactId>
+      <version>${awaitility.version}</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
 </project>

--- a/extension/core/src/main/kotlin/io/holixon/axon/projection/adhoc/EventApplier.kt
+++ b/extension/core/src/main/kotlin/io/holixon/axon/projection/adhoc/EventApplier.kt
@@ -10,6 +10,15 @@ class EventApplier<T>(
 ) {
 
   /**
+   * Checks if the given event message is relevant for the configured model.
+   *
+   * @param event the event message
+   * @return true if the event message can be handled by the model, otherwise false
+   */
+  fun <E> isRelevant(event: DomainEventMessage<E>): Boolean =
+    modelInspector.findEventHandler(event.payloadType) != null
+
+  /**
    * Tries to apply the given event to the given model instance.
    * <ul>
    *   <li>if no annotated MessageHandler is found for the domainEvent's payload type, the model will be returned untouched. </li>

--- a/extension/core/src/main/kotlin/io/holixon/axon/projection/adhoc/LRUCache.kt
+++ b/extension/core/src/main/kotlin/io/holixon/axon/projection/adhoc/LRUCache.kt
@@ -18,8 +18,8 @@ class LRUCache(val maxSize: Int) : Cache {
     }
   })
 
-  override fun <K : Any?, V : Any?> get(key: K): V {
-    return internalCache[key] as V
+  override fun <K : Any?, V : Any?> get(key: K): V? {
+    return internalCache[key]?.let { it as V }
   }
 
   override fun put(key: Any?, value: Any?) {

--- a/extension/core/src/main/kotlin/io/holixon/axon/projection/adhoc/LRUCache.kt
+++ b/extension/core/src/main/kotlin/io/holixon/axon/projection/adhoc/LRUCache.kt
@@ -1,15 +1,23 @@
-package io.holixon.axon.projection.adhoc._itestbase
+package io.holixon.axon.projection.adhoc
 
 import org.axonframework.common.Registration
 import org.axonframework.common.caching.Cache
+import java.util.Collections
 
+/**
+ * Cache implementation providing a least-recently-used behavior. The cache has a fixed maximum size. When the cache is full and an item is
+ * added to the cache, the element is removed which last access was the longest ago.
+ *
+ * @param maxSize the max size of this cache
+ */
 class LRUCache(val maxSize: Int) : Cache {
 
-  private val internalCache: MutableMap<Any?, Any?> = object : LinkedHashMap<Any?, Any?>(0, 0.75f, true) {
+  private val internalCache: MutableMap<Any?, Any?> = Collections.synchronizedMap(object : LinkedHashMap<Any?, Any?>(0, 0.75f, true) {
     override fun removeEldestEntry(eldest: MutableMap.MutableEntry<Any?, Any?>?): Boolean {
       return size > maxSize
     }
-  }
+  })
+
   override fun <K : Any?, V : Any?> get(key: K): V {
     return internalCache[key] as V
   }

--- a/extension/core/src/main/kotlin/io/holixon/axon/projection/adhoc/ModelRepository.kt
+++ b/extension/core/src/main/kotlin/io/holixon/axon/projection/adhoc/ModelRepository.kt
@@ -5,42 +5,54 @@ import org.axonframework.common.caching.Cache
 import org.axonframework.common.caching.Cache.EntryListenerAdapter
 import org.axonframework.common.caching.NoCache
 import org.axonframework.eventsourcing.eventstore.EventStore
+import java.time.Instant
 import java.util.*
 
 /**
  * Central component for building ad-hoc projections. THe ModelRepository looks for methods and constructors in the modelClass annotated
  * with Axon's @MessageHandler. When constructing the model instance the domain events will be applied using the annotated methods.
- * The result is put into the given cache.
+ * The result is put into the given cache.<br/>
+ * <br/>
+ * When a cached version is found, by default the Axon server will always be called for new events. With the config parameter
+ * <code>cacheRefreshTime</code> a duration (in ms) can be defined for which the cached entry will be considered as up-to-date without
+ * checking for new events in the event store.
  *
  * @param eventStore the axon eventStore to use
  * @param modelClass the model class type to build the projection on
- * @param cache the cache to use
+ * @param config the repository config to apply
  */
 open class ModelRepository<T : Any>(
   private val eventStore: EventStore,
   private val modelClass: Class<T>,
-  protected val cache: Cache = NoCache.INSTANCE
+  protected val config: ModelRepositoryConfig = ModelRepositoryConfig.defaults(),
 ) {
   companion object : KLogging()
 
-  init {
-    cache.registerCacheEntryListener(LoggingCacheEntryListener(modelClass.simpleName))
-  }
-
+  protected val cache: Cache = config.cache
   private val modelInspector = ModelInspector(modelClass)
   private val modelFactory = ModelFactory(modelInspector)
   protected val eventApplier = EventApplier(modelInspector)
 
+  init {
+    require(config.cacheRefreshTime >= 0L) { "The cache refresh time must not be negative" }
+    cache.registerCacheEntryListener(LoggingCacheEntryListener(modelClass.simpleName))
+  }
+
   /**
    * Looks for all events of this aggregateId and constructs a model instance. If a cached version exists, only the remaining new events
-   * are applied to the cached instance. THe final model instance will again be put into the cache.
+   * are applied to the cached instance. The final model instance will again be put into the cache.
    *
    * @param aggregateId the aggregateId
    * @return either the built model or an empty optional if the aggregateId had no events
    */
   fun findById(aggregateId: String): Optional<T> {
     return if (cache.containsKey(aggregateId)) {
-      Optional.of(readAndUpdateModelFromCache(aggregateId))
+      val cacheEntry: CacheEntry<T> = cache[aggregateId]
+      if (config.cacheRefreshTime == 0L || cacheEntry.created.isBefore(Instant.now().minusMillis(config.cacheRefreshTime))) {
+        Optional.of(readAndUpdateModelFromCache(aggregateId))
+      } else {
+        Optional.of(cacheEntry.model)
+      }
     } else {
       readModelFromScratch(aggregateId)
     }
@@ -70,10 +82,10 @@ open class ModelRepository<T : Any>(
     events
       .filter { it.sequenceNumber <= seqNo }
       .forEachRemaining { event ->
-      logger.debug { "Reading event ${event.payloadType.simpleName} with seqNo ${event.sequenceNumber} for aggregate ID $aggregateId" }
-      lastSeqNo = event.sequenceNumber
-      model = eventApplier.applyEvent(model, event)
-    }
+        logger.debug { "Reading event ${event.payloadType.simpleName} with seqNo ${event.sequenceNumber} for aggregate ID $aggregateId" }
+        lastSeqNo = event.sequenceNumber
+        model = eventApplier.applyEvent(model, event)
+      }
 
     return CacheEntry(aggregateId, lastSeqNo, model)
   }
@@ -85,8 +97,13 @@ open class ModelRepository<T : Any>(
 
     val lastSeqNo = eventStore.lastSequenceNumberFor(aggregateId).orElseThrow()
 
+    // cache still uptodate, can directly return cache entry
     if (lastSeqNo == currentCacheEntry.seqNo) {
-      // cache still uptodate, can directly return cache entry
+      // refresh cache timestamp only when too old
+      if (config.cacheRefreshTime != 0L && currentCacheEntry.created.isBefore(Instant.now().minusMillis(config.cacheRefreshTime))) {
+        cache.put(aggregateId, currentCacheEntry.copy(created = Instant.now()))
+      }
+
       return currentCacheEntry.model
     }
     var model: T = currentCacheEntry.model
@@ -96,9 +113,9 @@ open class ModelRepository<T : Any>(
     events
       .filter { it.sequenceNumber <= seqNo }
       .forEachRemaining { event ->
-      logger.debug { "Reading event ${event.payloadType.simpleName} with seqNo ${event.sequenceNumber} for aggregate ID $aggregateId" }
-      model = eventApplier.applyEvent(model, event)
-    }
+        logger.debug { "Reading event ${event.payloadType.simpleName} with seqNo ${event.sequenceNumber} for aggregate ID $aggregateId" }
+        model = eventApplier.applyEvent(model, event)
+      }
 
     val newCacheEntry = CacheEntry(aggregateId, lastSeqNo, model)
     cache.put(aggregateId, newCacheEntry)
@@ -112,23 +129,23 @@ open class ModelRepository<T : Any>(
     companion object : KLogging()
 
     override fun onEntryCreated(key: Any?, value: Any?) {
-      logger.debug { "$cacheName: Cache entry $key created" }
+      logger.trace { "$cacheName: Cache entry $key created" }
     }
 
     override fun onEntryExpired(key: Any?) {
-      logger.debug { "$cacheName: Cache entry $key expired" }
+      logger.trace { "$cacheName: Cache entry $key expired" }
     }
 
     override fun onEntryRemoved(key: Any?) {
-      logger.debug { "$cacheName: Cache entry $key removed" }
+      logger.trace { "$cacheName: Cache entry $key removed" }
     }
   }
-
 }
 
-internal class CacheEntry<T>(
+internal data class CacheEntry<T>(
   val aggregateId: String,
   val seqNo: Long,
-  val model: T
+  val model: T,
+  val created: Instant = Instant.now(),
 )
 

--- a/extension/core/src/main/kotlin/io/holixon/axon/projection/adhoc/ModelRepositoryConfig.kt
+++ b/extension/core/src/main/kotlin/io/holixon/axon/projection/adhoc/ModelRepositoryConfig.kt
@@ -1,0 +1,54 @@
+package io.holixon.axon.projection.adhoc
+
+import org.axonframework.common.caching.Cache
+
+/**
+ * The model repository config.
+ *
+ * @param cache the cache implementation to use
+ * @param cacheRefreshTime Time in ms a cache entry is considered up-to-date
+ * @param forceCacheInsert configures the behavior when an event of an uncached entity is received
+ */
+data class ModelRepositoryConfig(
+  /**
+   * The cache implementation to use. Default is an LRU-Cache of size 1024
+   */
+  val cache: Cache = LRUCache(1024),
+  /**
+   * Time in ms a cache entry is considered up-to-date and no eventStore will be queried for new/missed events. Default is 0.<br/>
+   * When using the <code>UpdatingModelRepository</code> consider a value other than 0 to use the advantage of the self-updating repo.
+   */
+  val cacheRefreshTime: Long = 0L,
+  /**
+   * Just for UpdatingModelRepository - Configures the behavior when an event of an uncached entity is received. When <code>false</code>
+   * the event is ignored, when <code>true</code>, a full replay of this entity is performed and the result is added to the cache. Default is <code>false</code>
+   */
+  val forceCacheInsert: Boolean = false
+) {
+  companion object {
+    fun defaults() = ModelRepositoryConfig()
+  }
+
+  /**
+   * The cache implementation to use. Default is an LRU-Cache of size 1024
+   *
+   * @param cache the cache to use
+   */
+  fun withCache(cache: Cache): ModelRepositoryConfig = copy(cache = cache)
+
+  /**
+   * Time in ms a cache entry is considered up-to-date and no eventStore will be queried for new/missed events. Default is 0.<br/>
+   * When using the <code>UpdatingModelRepository</code> consider a value other than 0 to use the advantage of the self-updating repo.
+   *
+   * @param cacheRefreshTime the cacheRefreshTime
+   */
+  fun withCacheRefreshTime(cacheRefreshTime: Long): ModelRepositoryConfig = copy(cacheRefreshTime = cacheRefreshTime)
+
+  /**
+   * Just for UpdatingModelRepository - Configures the behavior when an event of an uncached entity is received. When <code>false</code>
+   * the event is ignored, when <code>true</code>, a full replay of this entity is performed and the result is added to the cache. Default is <code>false</code>
+   *
+   * @param forceCacheInsert if new events always trigger cache inserts
+   */
+  fun withForceCacheInsert(forceCacheInsert: Boolean): ModelRepositoryConfig = copy(forceCacheInsert = forceCacheInsert)
+}

--- a/extension/core/src/main/kotlin/io/holixon/axon/projection/adhoc/ModelRepositoryConfig.kt
+++ b/extension/core/src/main/kotlin/io/holixon/axon/projection/adhoc/ModelRepositoryConfig.kt
@@ -26,6 +26,9 @@ data class ModelRepositoryConfig(
   val forceCacheInsert: Boolean = false
 ) {
   companion object {
+    /**
+     * Returns a config with default settings.
+     */
     fun defaults() = ModelRepositoryConfig()
   }
 

--- a/extension/core/src/main/kotlin/io/holixon/axon/projection/adhoc/UpdatingModelRepository.kt
+++ b/extension/core/src/main/kotlin/io/holixon/axon/projection/adhoc/UpdatingModelRepository.kt
@@ -21,15 +21,13 @@ import org.axonframework.messaging.annotation.MessageHandler
  *
  * @param eventStore the axon eventStore to use
  * @param modelClass the model class type to build the projection on
- * @param cache the cache to use
- * @param forceCacheInsert forces cache insert when model is absent
+ * @param config the repository config to apply
  */
 open class UpdatingModelRepository<T : Any>(
   eventStore: EventStore,
   modelClass: Class<T>,
-  cache: Cache = NoCache.INSTANCE,
-  private val forceCacheInsert: Boolean = false
-) : ModelRepository<T>(eventStore, modelClass, cache) {
+  config: ModelRepositoryConfig = ModelRepositoryConfig.defaults(),
+) : ModelRepository<T>(eventStore, modelClass, config) {
 
   companion object : KLogging()
 
@@ -64,7 +62,7 @@ open class UpdatingModelRepository<T : Any>(
 
     if (cacheEntry != null) {
       handleCacheEntry(eventMessage, cacheEntry)
-    } else if (forceCacheInsert) {
+    } else if (config.forceCacheInsert) {
       // create cache entry up to this event and store it
       logger.debug { "Aggregate ${eventMessage.aggregateIdentifier} was not found in eventStore, replay up to seqNo ${eventMessage.sequenceNumber} and store in cache" }
       readModelFromScratch(eventMessage.aggregateIdentifier, eventMessage.sequenceNumber)
@@ -110,7 +108,7 @@ open class UpdatingModelRepository<T : Any>(
    * A listener to the repository firing every time a cached instance was created or changed
    */
   @FunctionalInterface
-  interface ModelUpdatedListener<T> {
+  fun interface ModelUpdatedListener<T> {
 
     /**
      * Will be called with the new model instance every time the model instance is changed.

--- a/extension/core/src/main/kotlin/io/holixon/axon/projection/adhoc/UpdatingModelRepository.kt
+++ b/extension/core/src/main/kotlin/io/holixon/axon/projection/adhoc/UpdatingModelRepository.kt
@@ -1,0 +1,85 @@
+package io.holixon.axon.projection.adhoc
+
+import mu.KLogging
+import org.axonframework.common.caching.Cache
+import org.axonframework.common.caching.NoCache
+import org.axonframework.eventhandling.DomainEventMessage
+import org.axonframework.eventhandling.EventHandler
+import org.axonframework.eventhandling.EventMessage
+import org.axonframework.eventsourcing.eventstore.EventStore
+import org.axonframework.messaging.annotation.MessageHandler
+
+open class UpdatingModelRepository<T : Any>(
+  eventStore: EventStore,
+  modelClass: Class<T>,
+  cache: Cache = NoCache.INSTANCE,
+  private val forceCacheInsert: Boolean = false
+) : ModelRepository<T>(eventStore, modelClass, cache) {
+
+  companion object : KLogging()
+
+  private var modelUpdatedListeners: MutableList<ModelUpdatedListener<T>> = mutableListOf()
+
+  fun addModelUpdatedListener(listener: ModelUpdatedListener<T>) {
+    modelUpdatedListeners.add(listener)
+  }
+
+  fun removeModelUpdatedListener(listener: ModelUpdatedListener<T>) {
+    modelUpdatedListeners.remove(listener)
+  }
+
+  @MessageHandler(messageType = DomainEventMessage::class)
+  fun on(eventMessage: DomainEventMessage<Any>) {
+    logger.debug { "Event ${eventMessage.payloadType} of aggregate ${eventMessage.aggregateIdentifier}" }
+
+    val cacheEntry: CacheEntry<T>? = cache.get(eventMessage.aggregateIdentifier)
+
+    if (cacheEntry != null) {
+      handleCacheEntry(eventMessage, cacheEntry)
+    } else if (forceCacheInsert) {
+      // create cache entry up to this event and store it
+      logger.debug { "Aggregate ${eventMessage.aggregateIdentifier} was not found in eventStore, replay up to seqNo ${eventMessage.sequenceNumber} and store in cache" }
+      readModelFromScratch(eventMessage.aggregateIdentifier, eventMessage.sequenceNumber)
+        .ifPresent { callEventListener(it) }
+    }
+  }
+
+  private fun handleCacheEntry(eventMessage: DomainEventMessage<Any>, cacheEntry: CacheEntry<T>) {
+    val seqNo = eventMessage.sequenceNumber
+    val aggregateIdentifier = eventMessage.aggregateIdentifier
+
+    if (cacheEntry.seqNo + 1 == seqNo) {
+      logger.debug { "Updating cache entry for aggregate $aggregateIdentifier seqNo $seqNo" }
+      // cacheEntry is exactly one event behind, apply the event and update cache
+      if (eventApplier.isRelevant(eventMessage)) {
+        val newCacheEntry = applySingleEventToCacheEntry(cacheEntry, eventMessage)
+        cache.put(aggregateIdentifier, newCacheEntry)
+        callEventListener(newCacheEntry.model)
+      }
+    } else if (cacheEntry.seqNo + 1 < seqNo) {
+      logger.debug { "Cached aggregate $aggregateIdentifier is of version ${cacheEntry.seqNo} which is too old for new event $seqNo - replaying missing events" }
+      // did we miss some events? Update the cache entry to this event and store it
+      readAndUpdateModelFromCache(aggregateIdentifier, seqNo)
+        .also { callEventListener(it) }
+    } else if (cacheEntry.seqNo >= seqNo) {
+      // must be a replay, ignore it
+      logger.debug { "Cached aggregate $aggregateIdentifier is of version ${cacheEntry.seqNo} which is too new for new event $seqNo - seems to be a replay in progress, ignoring event" }
+    }
+  }
+
+  private fun applySingleEventToCacheEntry(cacheEntry: CacheEntry<T>, eventMessage: DomainEventMessage<Any>): CacheEntry<T> {
+    val newModel = eventApplier.applyEvent(cacheEntry.model, eventMessage)
+
+    return CacheEntry(eventMessage.aggregateIdentifier, eventMessage.sequenceNumber, newModel)
+  }
+
+  private fun callEventListener(model: T) {
+    logger.debug { "Trigger modelUpdatedListener $model" }
+    modelUpdatedListeners.forEach { it.modelUpdated(model) }
+  }
+
+  @FunctionalInterface
+  interface ModelUpdatedListener<T> {
+    fun modelUpdated(model: T)
+  }
+}

--- a/extension/core/src/test/kotlin/io/holixon/axon/projection/adhoc/EventApplierTest.kt
+++ b/extension/core/src/test/kotlin/io/holixon/axon/projection/adhoc/EventApplierTest.kt
@@ -1,0 +1,35 @@
+package io.holixon.axon.projection.adhoc
+
+import io.holixon.axon.projection.adhoc.dummy.*
+import io.mockk.every
+import io.mockk.mockk
+import org.assertj.core.api.Assertions.assertThat
+import org.axonframework.eventhandling.DomainEventMessage
+import org.axonframework.eventhandling.EventHandler
+import org.axonframework.eventhandling.SequenceNumber
+import org.axonframework.messaging.annotation.MessageHandler
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+class EventApplierTest {
+
+  @Test
+  fun `event is relevant for model`() {
+    val eventApplier = EventApplier(ModelInspector(CurrentBalanceImmutableModel::class.java))
+
+    val event = mockk<DomainEventMessage<MoneyDepositedEvent>>()
+    every { event.payloadType } returns MoneyDepositedEvent::class.java
+
+    assertThat(eventApplier.isRelevant(event)).isTrue()
+  }
+
+  @Test
+  fun `event is not relevant for model`() {
+    val eventApplier = EventApplier(ModelInspector(CurrentBalanceImmutableModel::class.java))
+
+    val event = mockk<DomainEventMessage<OwnerChangedEvent>>()
+    every { event.payloadType } returns OwnerChangedEvent::class.java
+
+    assertThat(eventApplier.isRelevant(event)).isFalse()
+  }
+}

--- a/extension/core/src/test/kotlin/io/holixon/axon/projection/adhoc/ModelRepositoryITest.kt
+++ b/extension/core/src/test/kotlin/io/holixon/axon/projection/adhoc/ModelRepositoryITest.kt
@@ -1,5 +1,6 @@
 package io.holixon.axon.projection.adhoc
 
+import io.holixon.axon.projection.adhoc._itestbase.BaseSpringIntegrationTest
 import io.holixon.axon.projection.adhoc.dummy.*
 import org.assertj.core.api.Assertions
 import org.axonframework.eventhandling.GenericDomainEventMessage
@@ -11,12 +12,7 @@ import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
 import java.util.*
 
-@SpringBootTest(classes = [TestConfiguration::class])
-@ActiveProfiles("itest")
-class ModelRepositoryITest {
-
-  @Autowired
-  lateinit var eventStore: EventStore
+class ModelRepositoryITest : BaseSpringIntegrationTest() {
 
   @Test
   fun `immutable projection can be loaded`() {
@@ -57,12 +53,5 @@ class ModelRepositoryITest {
     Assertions.assertThat(secondModel).isPresent
     Assertions.assertThat(secondModel.get().currentBalanceInEuroCent).isEqualTo(110)
     Assertions.assertThat(secondModel.get().version).isEqualTo(4)
-  }
-
-  private fun <T> publishMessage(aggregateId: String, evt: T) {
-    val lastSeqNo = eventStore.lastSequenceNumberFor(aggregateId).orElse(-1)
-
-    eventStore.publish(GenericDomainEventMessage(evt!!::class.java.typeName, aggregateId, lastSeqNo + 1, evt))
-
   }
 }

--- a/extension/core/src/test/kotlin/io/holixon/axon/projection/adhoc/ModelRepositoryTest.kt
+++ b/extension/core/src/test/kotlin/io/holixon/axon/projection/adhoc/ModelRepositoryTest.kt
@@ -5,6 +5,7 @@ import io.holixon.axon.projection.adhoc.dummy.CurrentBalanceImmutableModel
 import io.holixon.axon.projection.adhoc.dummy.MoneyDepositedEvent
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.slot
 import io.mockk.verify
 import org.assertj.core.api.Assertions.assertThat
 import org.axonframework.common.caching.Cache
@@ -41,6 +42,31 @@ class ModelRepositoryTest {
     verify { eventStore.readEvents(eq(bankAccountId.toString())) }
     verify { cache.containsKey(eq(bankAccountId.toString())) }
     verify { cache.put(eq(bankAccountId.toString()), any()) }
+  }
+
+  @Test
+  fun `create model versioned from scratch`() {
+    val bankAccountId = UUID.randomUUID()
+    mockEventStore(
+      bankAccountId, listOf(
+        BankAccountCreatedEvent(bankAccountId, "Alice"),
+        MoneyDepositedEvent(bankAccountId, 100),
+        MoneyDepositedEvent(bankAccountId, 30),
+        MoneyDepositedEvent(bankAccountId, 10),
+      )
+    )
+
+    val model = repository.readModelFromScratch(bankAccountId.toString(), 1)
+
+    assertThat(model).isPresent
+
+    val cacheEntrySlot = slot<CacheEntry<CurrentBalanceImmutableModel>>()
+
+    verify { eventStore.readEvents(eq(bankAccountId.toString())) }
+    verify { cache.put(eq(bankAccountId.toString()), capture(cacheEntrySlot)) }
+
+    assertThat(cacheEntrySlot.captured.seqNo).isEqualTo(1)
+    assertThat(cacheEntrySlot.captured.model.currentBalanceInEuroCent).isEqualTo(100)
   }
 
   @Test

--- a/extension/core/src/test/kotlin/io/holixon/axon/projection/adhoc/TestConfiguration.kt
+++ b/extension/core/src/test/kotlin/io/holixon/axon/projection/adhoc/TestConfiguration.kt
@@ -1,13 +1,18 @@
 package io.holixon.axon.projection.adhoc
 
+import io.holixon.axon.projection.adhoc._itestbase.LRUCache
+import io.holixon.axon.projection.adhoc.dummy.CurrentBalanceImmutableModel
+import org.axonframework.common.caching.Cache
 import org.axonframework.common.transaction.TransactionManager
 import org.axonframework.config.ConfigurationScopeAwareProvider
 import org.axonframework.deadline.DeadlineManager
 import org.axonframework.deadline.SimpleDeadlineManager
 import org.axonframework.eventhandling.tokenstore.inmemory.InMemoryTokenStore
+import org.axonframework.eventsourcing.eventstore.EventStore
 import org.axonframework.eventsourcing.eventstore.inmemory.InMemoryEventStorageEngine
 import org.axonframework.modelling.saga.repository.inmemory.InMemorySagaStore
 import org.axonframework.spring.config.SpringConfigurer
+import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
@@ -40,4 +45,17 @@ class TestConfiguration {
     SimpleDeadlineManager.builder().scopeAwareProvider(ConfigurationScopeAwareProvider(configurer.buildConfiguration()))
       .transactionManager(transactionManager).build()
 
+  @Bean
+  fun updateCache() = LRUCache(256)
+
+  @Bean
+  fun forceUpdateCache() = LRUCache(256)
+
+  @Bean
+  fun updatingCurrentBalanceModelRepository(eventStore: EventStore, @Qualifier("updateCache") cache: Cache) =
+    UpdatingModelRepository(eventStore, CurrentBalanceImmutableModel::class.java, cache, false)
+
+  @Bean
+  fun forceUpdatingCurrentBalanceModelRepository(eventStore: EventStore, @Qualifier("forceUpdateCache") cache: Cache) =
+    UpdatingModelRepository(eventStore, CurrentBalanceImmutableModel::class.java, cache, true)
 }

--- a/extension/core/src/test/kotlin/io/holixon/axon/projection/adhoc/TestConfiguration.kt
+++ b/extension/core/src/test/kotlin/io/holixon/axon/projection/adhoc/TestConfiguration.kt
@@ -1,6 +1,5 @@
 package io.holixon.axon.projection.adhoc
 
-import io.holixon.axon.projection.adhoc._itestbase.LRUCache
 import io.holixon.axon.projection.adhoc.dummy.CurrentBalanceImmutableModel
 import org.axonframework.common.caching.Cache
 import org.axonframework.common.transaction.TransactionManager
@@ -53,9 +52,9 @@ class TestConfiguration {
 
   @Bean
   fun updatingCurrentBalanceModelRepository(eventStore: EventStore, @Qualifier("updateCache") cache: Cache) =
-    UpdatingModelRepository(eventStore, CurrentBalanceImmutableModel::class.java, cache, false)
+    UpdatingModelRepository(eventStore, CurrentBalanceImmutableModel::class.java, ModelRepositoryConfig(cache = cache))
 
   @Bean
   fun forceUpdatingCurrentBalanceModelRepository(eventStore: EventStore, @Qualifier("forceUpdateCache") cache: Cache) =
-    UpdatingModelRepository(eventStore, CurrentBalanceImmutableModel::class.java, cache, true)
+    UpdatingModelRepository(eventStore, CurrentBalanceImmutableModel::class.java, ModelRepositoryConfig(cache = cache, forceCacheInsert = true))
 }

--- a/extension/core/src/test/kotlin/io/holixon/axon/projection/adhoc/UpdatingModelRepositoryITest.kt
+++ b/extension/core/src/test/kotlin/io/holixon/axon/projection/adhoc/UpdatingModelRepositoryITest.kt
@@ -1,0 +1,120 @@
+package io.holixon.axon.projection.adhoc
+
+import io.holixon.axon.projection.adhoc._itestbase.BaseSpringIntegrationTest
+import io.holixon.axon.projection.adhoc.dummy.BankAccountCreatedEvent
+import io.holixon.axon.projection.adhoc.dummy.CurrentBalanceImmutableModel
+import io.holixon.axon.projection.adhoc.dummy.MoneyDepositedEvent
+import io.holixon.axon.projection.adhoc.dummy.MoneyWithdrawnEvent
+import org.assertj.core.api.Assertions.assertThat
+import org.awaitility.kotlin.await
+import org.awaitility.kotlin.untilAsserted
+import org.axonframework.common.caching.Cache
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.beans.factory.annotation.Qualifier
+import java.util.*
+
+class UpdatingModelRepositoryITest : BaseSpringIntegrationTest() {
+
+  @Autowired
+  @Qualifier("updatingCurrentBalanceModelRepository")
+  lateinit var repository: UpdatingModelRepository<CurrentBalanceImmutableModel>
+
+  @Autowired
+  @Qualifier("forceUpdatingCurrentBalanceModelRepository")
+  lateinit var forceUpdatingRepository: UpdatingModelRepository<CurrentBalanceImmutableModel>
+
+  @Autowired
+  @Qualifier("updateCache")
+  lateinit var updateCache: Cache
+
+  @Autowired
+  @Qualifier("forceUpdateCache")
+  lateinit var forceUpdateCache: Cache
+
+  val cacheUpdateLogger = CacheUpdateLogger()
+  val forcedCacheUpdateLogger = CacheUpdateLogger()
+
+  @BeforeEach
+  fun beforeEach() {
+    repository.addModelUpdatedListener(cacheUpdateLogger)
+    forceUpdatingRepository.addModelUpdatedListener(forcedCacheUpdateLogger)
+  }
+
+  @AfterEach
+  fun afterEach() {
+    repository.removeModelUpdatedListener(cacheUpdateLogger)
+    forceUpdatingRepository.removeModelUpdatedListener(forcedCacheUpdateLogger)
+  }
+
+  @Test
+  fun `immutable projection can be loaded`() {
+    val bankAccountId = UUID.randomUUID()
+    publishMessage(bankAccountId.toString(), BankAccountCreatedEvent(bankAccountId, ""))
+    publishMessage(bankAccountId.toString(), MoneyDepositedEvent(bankAccountId, 100))
+    publishMessage(bankAccountId.toString(), MoneyWithdrawnEvent(bankAccountId, 50))
+
+    val model = repository.findById(bankAccountId.toString())
+
+    assertThat(model).isPresent
+    assertThat(model.get().currentBalanceInEuroCent).isEqualTo(50)
+    assertThat(model.get().version).isEqualTo(2)
+  }
+
+  @Test
+  fun `cache is updated automatically`() {
+    val bankAccountId = UUID.randomUUID()
+    publishMessage(bankAccountId.toString(), BankAccountCreatedEvent(bankAccountId, ""))
+    publishMessage(bankAccountId.toString(), MoneyDepositedEvent(bankAccountId, 100))
+    publishMessage(bankAccountId.toString(), MoneyWithdrawnEvent(bankAccountId, 50))
+
+    assertThat(updateCache.containsKey(bankAccountId.toString())).isFalse()
+
+    repository.findById(bankAccountId.toString())
+
+    assertThat(updateCache.containsKey(bankAccountId.toString())).isTrue()
+
+    publishMessage(bankAccountId.toString(), MoneyWithdrawnEvent(bankAccountId, 40))
+
+    await untilAsserted {
+      val cachedModel: CacheEntry<CurrentBalanceImmutableModel> = updateCache[bankAccountId.toString()]
+      assertThat(cachedModel.seqNo).isEqualTo(3)
+      assertThat(cachedModel.model.currentBalanceInEuroCent).isEqualTo(10)
+
+      assertThat(cacheUpdateLogger.updates).containsKey(bankAccountId)
+      assertThat(cacheUpdateLogger.updates[bankAccountId]).hasSize(1)
+      assertThat(cacheUpdateLogger.updates[bankAccountId]!![0].currentBalanceInEuroCent).isEqualTo(10)
+    }
+  }
+
+  @Test
+  fun `cache is inserted automatically on forceInsert=true`() {
+    val bankAccountId = UUID.randomUUID()
+    publishMessage(bankAccountId.toString(), BankAccountCreatedEvent(bankAccountId, ""))
+    publishMessage(bankAccountId.toString(), MoneyDepositedEvent(bankAccountId, 100))
+    publishMessage(bankAccountId.toString(), MoneyWithdrawnEvent(bankAccountId, 50))
+
+    await untilAsserted {
+      assertThat(forceUpdateCache.containsKey(bankAccountId.toString())).isTrue()
+      val cachedModel: CacheEntry<CurrentBalanceImmutableModel> = forceUpdateCache[bankAccountId.toString()]
+      assertThat(cachedModel.seqNo).isEqualTo(2)
+      assertThat(cachedModel.model.currentBalanceInEuroCent).isEqualTo(50)
+
+      assertThat(forcedCacheUpdateLogger.updates).containsKey(bankAccountId)
+      assertThat(forcedCacheUpdateLogger.updates[bankAccountId]).hasSize(3)
+      assertThat(forcedCacheUpdateLogger.updates[bankAccountId]!![2].currentBalanceInEuroCent).isEqualTo(50)
+    }
+  }
+
+  class CacheUpdateLogger : UpdatingModelRepository.ModelUpdatedListener<CurrentBalanceImmutableModel> {
+    val updates = mutableMapOf<UUID, MutableList<CurrentBalanceImmutableModel>>()
+
+    override fun modelUpdated(model: CurrentBalanceImmutableModel) {
+      updates.putIfAbsent(model.bankAccountId, ArrayList())
+
+      updates[model.bankAccountId]!!.add(model)
+    }
+  }
+}

--- a/extension/core/src/test/kotlin/io/holixon/axon/projection/adhoc/UpdatingModelRepositoryTest.kt
+++ b/extension/core/src/test/kotlin/io/holixon/axon/projection/adhoc/UpdatingModelRepositoryTest.kt
@@ -1,0 +1,191 @@
+package io.holixon.axon.projection.adhoc
+
+import io.holixon.axon.projection.adhoc.dummy.BankAccountCreatedEvent
+import io.holixon.axon.projection.adhoc.dummy.BankAccountEvent
+import io.holixon.axon.projection.adhoc.dummy.CurrentBalanceImmutableModel
+import io.holixon.axon.projection.adhoc.dummy.MoneyDepositedEvent
+import io.mockk.*
+import org.assertj.core.api.Assertions.assertThat
+import org.axonframework.common.Registration
+import org.axonframework.common.caching.Cache
+import org.axonframework.eventhandling.DomainEventMessage
+import org.axonframework.eventhandling.GenericDomainEventMessage
+import org.axonframework.eventsourcing.eventstore.EventStore
+import org.axonframework.eventsourcing.eventstore.IteratorBackedDomainEventStream
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.time.Instant
+import java.util.*
+
+class UpdatingModelRepositoryTest {
+
+  private val cache = mockk<Cache>().also {
+    every { it.registerCacheEntryListener(any()) } returns Registration { true }
+    every { it.containsKey(any()) } returns false
+    every { it.get<String, CacheEntry<CurrentBalanceImmutableModel>>(any()) } returns null
+    justRun { it.put(any(), any()) }
+  }
+
+  private val eventStore = mockk<EventStore>()
+
+  private val repository =
+    UpdatingModelRepository(eventStore, CurrentBalanceImmutableModel::class.java, ModelRepositoryConfig(cache = cache))
+
+  @Test
+  fun `update model in cache`() {
+    val bankAccountId = UUID.randomUUID()
+    mockEventStore(
+      listOf(
+        BankAccountCreatedEvent(bankAccountId, "Alice")
+      )
+    )
+    every { cache.containsKey(eq(bankAccountId.toString())) } returns true
+    every { cache.get<String, CacheEntry<CurrentBalanceImmutableModel>>(eq(bankAccountId.toString())) } returns
+      CacheEntry(
+        bankAccountId.toString(),
+        0,
+        CurrentBalanceImmutableModel(BankAccountCreatedEvent(bankAccountId, "Alice"), Instant.now(), 0)
+      )
+
+    repository.on(convertToDomainEventMessage(MoneyDepositedEvent(bankAccountId, 100), 1L))
+
+    val cacheEntrySlot = slot<CacheEntry<CurrentBalanceImmutableModel>>()
+
+    verify(exactly = 0) { eventStore.readEvents(eq(bankAccountId.toString())) }
+    verify { cache.put(eq(bankAccountId.toString()), capture(cacheEntrySlot)) }
+
+    assertThat(cacheEntrySlot.captured.seqNo).isEqualTo(1)
+    assertThat(cacheEntrySlot.captured.model.currentBalanceInEuroCent).isEqualTo(100)
+  }
+
+
+  @Test
+  fun `update model in cache - apply missed events`() {
+    val bankAccountId = UUID.randomUUID()
+    mockEventStore(
+      listOf(
+        BankAccountCreatedEvent(bankAccountId, "Alice"),
+        MoneyDepositedEvent(bankAccountId, 100),
+        MoneyDepositedEvent(bankAccountId, 100),
+        MoneyDepositedEvent(bankAccountId, 100),
+      )
+    )
+    every { cache.containsKey(eq(bankAccountId.toString())) } returns true
+    every { cache.get<String, CacheEntry<CurrentBalanceImmutableModel>>(eq(bankAccountId.toString())) } returns
+      CacheEntry(
+        bankAccountId.toString(),
+        0,
+        CurrentBalanceImmutableModel(BankAccountCreatedEvent(bankAccountId, "Alice"), Instant.now(), 0)
+      )
+
+    repository.on(convertToDomainEventMessage(MoneyDepositedEvent(bankAccountId, 100), 3L))
+
+    val cacheEntrySlot = slot<CacheEntry<CurrentBalanceImmutableModel>>()
+
+    verify { eventStore.readEvents(eq(bankAccountId.toString()), eq(1)) }
+    verify { cache.put(eq(bankAccountId.toString()), capture(cacheEntrySlot)) }
+
+    assertThat(cacheEntrySlot.captured.seqNo).isEqualTo(3)
+    assertThat(cacheEntrySlot.captured.model.currentBalanceInEuroCent).isEqualTo(300)
+  }
+
+  @Test
+  fun `force insert model in cache`() {
+    val bankAccountId = UUID.randomUUID()
+    mockEventStore(
+      listOf(
+        BankAccountCreatedEvent(bankAccountId, "Alice"),
+        MoneyDepositedEvent(bankAccountId, 100),
+        MoneyDepositedEvent(bankAccountId, 100),
+        MoneyDepositedEvent(bankAccountId, 100),
+      )
+    )
+    every { cache.containsKey(eq(bankAccountId.toString())) } returns false
+
+    val forceInsertRepository = UpdatingModelRepository(
+      eventStore,
+      CurrentBalanceImmutableModel::class.java,
+      ModelRepositoryConfig(cache = cache, forceCacheInsert = true)
+    )
+
+    forceInsertRepository.on(convertToDomainEventMessage(MoneyDepositedEvent(bankAccountId, 100), 3L))
+
+    val cacheEntrySlot = slot<CacheEntry<CurrentBalanceImmutableModel>>()
+
+    verify { eventStore.readEvents(eq(bankAccountId.toString())) }
+    verify { cache.put(eq(bankAccountId.toString()), capture(cacheEntrySlot)) }
+
+    assertThat(cacheEntrySlot.captured.seqNo).isEqualTo(3)
+    assertThat(cacheEntrySlot.captured.model.currentBalanceInEuroCent).isEqualTo(300)
+  }
+
+  @Test
+  fun `skip update model in cache - event is too new`() {
+    val bankAccountId = UUID.randomUUID()
+    every { cache.containsKey(eq(bankAccountId.toString())) } returns true
+    every { cache.get<String, CacheEntry<CurrentBalanceImmutableModel>>(eq(bankAccountId.toString())) } returns
+      CacheEntry(
+        bankAccountId.toString(),
+        1,
+        CurrentBalanceImmutableModel(BankAccountCreatedEvent(bankAccountId, "Alice"), Instant.now(), 0)
+          .on(MoneyDepositedEvent(bankAccountId, 100), Instant.now(), 0)
+      )
+
+    repository.on(convertToDomainEventMessage(MoneyDepositedEvent(bankAccountId, 100), 1L))
+
+    val cacheEntrySlot = slot<CacheEntry<CurrentBalanceImmutableModel>>()
+
+    // nothing should happen at all
+    verify(exactly = 0) { eventStore.readEvents(eq(bankAccountId.toString())) }
+    verify(exactly = 0) { cache.put(eq(bankAccountId.toString()), capture(cacheEntrySlot)) }
+  }
+
+  @Test
+  fun `update model in cache calls listeners`() {
+    val bankAccountId = UUID.randomUUID()
+    mockEventStore(
+      listOf(
+        BankAccountCreatedEvent(bankAccountId, "Alice")
+      )
+    )
+    every { cache.containsKey(eq(bankAccountId.toString())) } returns true
+    every { cache.get<String, CacheEntry<CurrentBalanceImmutableModel>>(eq(bankAccountId.toString())) } returns
+      CacheEntry(
+        bankAccountId.toString(),
+        0,
+        CurrentBalanceImmutableModel(BankAccountCreatedEvent(bankAccountId, "Alice"), Instant.now(), 0)
+      )
+    val listener = mockk<UpdatingModelRepository.ModelUpdatedListener<CurrentBalanceImmutableModel>>(relaxed = true)
+
+    repository.addModelUpdatedListener(listener)
+    repository.on(convertToDomainEventMessage(MoneyDepositedEvent(bankAccountId, 100), 1L))
+
+    val modelSlot = slot<CurrentBalanceImmutableModel>()
+
+    verify(exactly = 0) { eventStore.readEvents(eq(bankAccountId.toString())) }
+    verify { listener.modelUpdated(capture(modelSlot)) }
+
+    assertThat(modelSlot.captured.version).isEqualTo(1)
+    assertThat(modelSlot.captured.currentBalanceInEuroCent).isEqualTo(100)
+  }
+
+
+  private fun mockEventStore(events: List<BankAccountEvent>) {
+    var seqNo = -1L
+    val eventStream = IteratorBackedDomainEventStream(events.map {
+      convertToDomainEventMessage(it, ++seqNo)
+    }
+      .iterator())
+
+    val aggregateId = events.first().bankAccountId
+    every { eventStore.lastSequenceNumberFor(eq(aggregateId.toString())) } returns Optional.of(seqNo)
+    every { eventStore.readEvents(eq(aggregateId.toString())) } returns eventStream
+    every { eventStore.readEvents(eq(aggregateId.toString()), any()) } answers {
+      val firstSecNo = it.invocation.args[1] as Long
+      eventStream.filter { event -> event.sequenceNumber >= firstSecNo }
+    }
+  }
+
+  private fun convertToDomainEventMessage(event: BankAccountEvent, seqNo: Long): DomainEventMessage<Any> =
+    GenericDomainEventMessage(event.javaClass.typeName, event.bankAccountId.toString(), seqNo, event)
+}

--- a/extension/core/src/test/kotlin/io/holixon/axon/projection/adhoc/_itestbase/BaseSpringIntegrationTest.kt
+++ b/extension/core/src/test/kotlin/io/holixon/axon/projection/adhoc/_itestbase/BaseSpringIntegrationTest.kt
@@ -1,0 +1,23 @@
+package io.holixon.axon.projection.adhoc._itestbase
+
+import io.holixon.axon.projection.adhoc.TestConfiguration
+import org.axonframework.eventhandling.GenericDomainEventMessage
+import org.axonframework.eventsourcing.eventstore.EventStore
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+
+@SpringBootTest(classes = [TestConfiguration::class])
+@ActiveProfiles("itest")
+abstract class BaseSpringIntegrationTest {
+
+  @Autowired
+  lateinit var eventStore: EventStore
+
+  protected fun <T> publishMessage(aggregateId: String, evt: T) {
+    val lastSeqNo = eventStore.lastSequenceNumberFor(aggregateId).orElse(-1)
+
+    eventStore.publish(GenericDomainEventMessage(evt!!::class.java.typeName, aggregateId, lastSeqNo + 1, evt))
+
+  }
+}

--- a/extension/core/src/test/kotlin/io/holixon/axon/projection/adhoc/_itestbase/LRUCache.kt
+++ b/extension/core/src/test/kotlin/io/holixon/axon/projection/adhoc/_itestbase/LRUCache.kt
@@ -1,0 +1,29 @@
+package io.holixon.axon.projection.adhoc._itestbase
+
+import org.axonframework.common.Registration
+import org.axonframework.common.caching.Cache
+
+class LRUCache(val maxSize: Int) : Cache {
+
+  private val internalCache: MutableMap<Any?, Any?> = object : LinkedHashMap<Any?, Any?>(0, 0.75f, true) {
+    override fun removeEldestEntry(eldest: MutableMap.MutableEntry<Any?, Any?>?): Boolean {
+      return size > maxSize
+    }
+  }
+  override fun <K : Any?, V : Any?> get(key: K): V {
+    return internalCache[key] as V
+  }
+
+  override fun put(key: Any?, value: Any?) {
+    internalCache[key] = value
+  }
+
+  override fun putIfAbsent(key: Any?, value: Any?): Boolean =
+    internalCache.putIfAbsent(key, value) == null
+
+  override fun remove(key: Any?): Boolean = internalCache.remove(key) != null
+
+  override fun containsKey(key: Any?): Boolean = internalCache.containsKey(key)
+
+  override fun registerCacheEntryListener(cacheEntryListener: Cache.EntryListener?): Registration = Registration { true }
+}

--- a/extension/core/src/test/kotlin/io/holixon/axon/projection/adhoc/dummy/CurrentBalanceImmutableModel.kt
+++ b/extension/core/src/test/kotlin/io/holixon/axon/projection/adhoc/dummy/CurrentBalanceImmutableModel.kt
@@ -1,6 +1,10 @@
 package io.holixon.axon.projection.adhoc.dummy
 
 import io.holixon.axon.projection.adhoc.ModelRepository
+import io.holixon.axon.projection.adhoc.UpdatingModelRepository
+import io.holixon.axon.projection.adhoc._itestbase.LRUCache
+import org.axonframework.common.caching.Cache
+import org.axonframework.common.caching.NoCache
 import org.axonframework.common.caching.WeakReferenceCache
 import org.axonframework.eventhandling.EventHandler
 import org.axonframework.eventhandling.SequenceNumber
@@ -44,3 +48,6 @@ data class CurrentBalanceImmutableModel(
 
 class CurrentBalanceImmutableModelRepository(eventStore: EventStore) :
   ModelRepository<CurrentBalanceImmutableModel>(eventStore, CurrentBalanceImmutableModel::class.java, WeakReferenceCache())
+
+//class UpdatingCurrentBalanceImmutableModelRepository(eventStore: EventStore, cache: Cache, forceCacheInsert: Boolean) :
+//  UpdatingModelRepository<CurrentBalanceImmutableModel>(eventStore, CurrentBalanceImmutableModel::class.java, cache, forceCacheInsert)

--- a/extension/core/src/test/kotlin/io/holixon/axon/projection/adhoc/dummy/CurrentBalanceImmutableModel.kt
+++ b/extension/core/src/test/kotlin/io/holixon/axon/projection/adhoc/dummy/CurrentBalanceImmutableModel.kt
@@ -1,11 +1,6 @@
 package io.holixon.axon.projection.adhoc.dummy
 
 import io.holixon.axon.projection.adhoc.ModelRepository
-import io.holixon.axon.projection.adhoc.UpdatingModelRepository
-import io.holixon.axon.projection.adhoc._itestbase.LRUCache
-import org.axonframework.common.caching.Cache
-import org.axonframework.common.caching.NoCache
-import org.axonframework.common.caching.WeakReferenceCache
 import org.axonframework.eventhandling.EventHandler
 import org.axonframework.eventhandling.SequenceNumber
 import org.axonframework.eventhandling.Timestamp
@@ -47,7 +42,7 @@ data class CurrentBalanceImmutableModel(
 }
 
 class CurrentBalanceImmutableModelRepository(eventStore: EventStore) :
-  ModelRepository<CurrentBalanceImmutableModel>(eventStore, CurrentBalanceImmutableModel::class.java, WeakReferenceCache())
-
-//class UpdatingCurrentBalanceImmutableModelRepository(eventStore: EventStore, cache: Cache, forceCacheInsert: Boolean) :
-//  UpdatingModelRepository<CurrentBalanceImmutableModel>(eventStore, CurrentBalanceImmutableModel::class.java, cache, forceCacheInsert)
+  ModelRepository<CurrentBalanceImmutableModel>(
+    eventStore,
+    CurrentBalanceImmutableModel::class.java,
+  )

--- a/extension/core/src/test/kotlin/io/holixon/axon/projection/adhoc/dummy/CurrentBalanceMutableModel.kt
+++ b/extension/core/src/test/kotlin/io/holixon/axon/projection/adhoc/dummy/CurrentBalanceMutableModel.kt
@@ -1,7 +1,6 @@
 package io.holixon.axon.projection.adhoc.dummy
 
 import io.holixon.axon.projection.adhoc.ModelRepository
-import org.axonframework.common.caching.WeakReferenceCache
 import org.axonframework.eventhandling.EventHandler
 import org.axonframework.eventhandling.SequenceNumber
 import org.axonframework.eventhandling.Timestamp
@@ -40,4 +39,7 @@ class CurrentBalanceMutableModel {
 }
 
 class CurrentBalanceMutableModelRepository(eventStore: EventStore) :
-  ModelRepository<CurrentBalanceMutableModel>(eventStore, CurrentBalanceMutableModel::class.java, WeakReferenceCache())
+  ModelRepository<CurrentBalanceMutableModel>(
+    eventStore,
+    CurrentBalanceMutableModel::class.java,
+  )

--- a/extension/core/src/test/kotlin/io/holixon/axon/projection/adhoc/dummy/events.kt
+++ b/extension/core/src/test/kotlin/io/holixon/axon/projection/adhoc/dummy/events.kt
@@ -2,22 +2,26 @@ package io.holixon.axon.projection.adhoc.dummy
 
 import java.util.*
 
+interface BankAccountEvent {
+  val bankAccountId: UUID
+}
+
 data class BankAccountCreatedEvent(
-  val bankAccountId: UUID,
+  override val bankAccountId: UUID,
   val owner: String,
-)
+) : BankAccountEvent
 
 data class MoneyWithdrawnEvent(
-  val bankAccountId: UUID,
+  override val bankAccountId: UUID,
   val amountInEuroCent: Int
-)
+) : BankAccountEvent
 
 data class MoneyDepositedEvent(
-  val bankAccountId: UUID,
+  override val bankAccountId: UUID,
   val amountInEuroCent: Int
-)
+) : BankAccountEvent
 
 data class OwnerChangedEvent(
-  val bankAccountId: UUID,
+  override val bankAccountId: UUID,
   val owner: String
-)
+) : BankAccountEvent

--- a/extension/core/src/test/kotlin/io/holixon/axon/projection/adhoc/dummy/events.kt
+++ b/extension/core/src/test/kotlin/io/holixon/axon/projection/adhoc/dummy/events.kt
@@ -16,3 +16,8 @@ data class MoneyDepositedEvent(
   val bankAccountId: UUID,
   val amountInEuroCent: Int
 )
+
+data class OwnerChangedEvent(
+  val bankAccountId: UUID,
+  val owner: String
+)

--- a/pom.xml
+++ b/pom.xml
@@ -27,6 +27,7 @@
     <dom4j.version>2.1.4</dom4j.version>
     <jaxen.version>2.0.0</jaxen.version>
     <mockk.version>1.13.8</mockk.version>
+    <awaitility.version>4.2.0</awaitility.version>
 
     <!-- MAVEN -->
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>


### PR DESCRIPTION
Self-updating projection features two usecases:
- auto-updating projection cache with happening events when the cache entry itself is present
- auto-inserting new aggregates to the cache when events hit the event stream. Useful for pre-filling the cache